### PR TITLE
Fix send

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# example binaries
+main
+
+# credentials
+secrets.sh

--- a/examples/send_sms/main.go
+++ b/examples/send_sms/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"github.com/natebrennand/twiliogo"
+	"github.com/natebrennand/twiliogo/sms"
+)
+
+func main() {
+	act := twiliogo.NewAccountFromEnv()
+	resp, err := act.Sms.Send(sms.Post{
+		From: "+{Your twilio number}",
+		To:   "+{Destination number}",
+		Body: "Yo",
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%#v\n", resp)
+}

--- a/sms/example_test.go
+++ b/sms/example_test.go
@@ -1,4 +1,4 @@
-package main
+package sms_test
 
 import (
 	"fmt"
@@ -6,15 +6,15 @@ import (
 	"github.com/natebrennand/twiliogo/sms"
 )
 
-func main() {
-	act := twiliogo.NewAccountFromEnv()
+func Example_sendSms() {
+	act := twiliogo.NewAccount("AC1234567890abcdefghik1234567890ab", "token")
 	resp, err := act.Sms.Send(sms.Post{
 		From: "+{Your twilio number}",
 		To:   "+{Destination number}",
 		Body: "Yo",
 	})
 	if err != nil {
-		panic(err.Error())
 	}
-	fmt.Printf("%#v\n", resp)
+	fmt.Println(resp.Status)
+	// Output:
 }

--- a/sms/example_test.go
+++ b/sms/example_test.go
@@ -1,20 +1,15 @@
 package sms_test
 
 import (
-	"fmt"
 	"github.com/natebrennand/twiliogo"
 	"github.com/natebrennand/twiliogo/sms"
 )
 
 func Example_sendSms() {
 	act := twiliogo.NewAccount("AC1234567890abcdefghik1234567890ab", "token")
-	resp, err := act.Sms.Send(sms.Post{
+	act.Sms.Send(sms.Post{
 		From: "+{Your twilio number}",
 		To:   "+{Destination number}",
 		Body: "Yo",
 	})
-	if err != nil {
-	}
-	fmt.Println(resp.Status)
-	// Output:
 }

--- a/sms/fixtures_test.go
+++ b/sms/fixtures_test.go
@@ -9,12 +9,18 @@ var (
 	testNumber1                      = "+15558675309"
 	testNumber2                      = "+14158141829"
 	testSmsResponseFixtureAccountSid = "AC5ef8732a3c49700934481addd5ce1659"
-	testSmsPostFixture               = `{
+	testSmsPostFixtureString         = `{
 		"body":"Jenny please?! I love you <3",
 		"to":"+15558675309",
 		"from":"+14158141829",
 		"media_url":"http://www.example.com/hearts.png"
 	}`
+	testSmsPostFixture = Post{
+		Body:     "Jenny please?! I love you <3",
+		To:       "+15558675309",
+		From:     "+14158141829",
+		MediaUrl: "http://www.example.com/hearts.png",
+	}
 	testSmsResponseFixtureString = `{
 		"account_sid": "AC5ef8732a3c49700934481addd5ce1659",
 		"api_version": "2010-04-01",


### PR DESCRIPTION
send now properly works. Couldn't see to get it to using the json body but I probably just couldn't find the right `Content-Type`.

[If you run godoc locally, it will show the example](https://photos-4.dropbox.com/t/0/AAC2GA9wfT54oeLSt8RVHJv2Wi8SuLRfoJ9bU9EOmT2MXQ/12/15239096/png/1024x768/3/1404842400/0/2/Screenshot%202014-07-08%2009.51.29.png/FvHn2kGS6AStEbOQSEjmFi6_USpmAESP1cGQQ6I9C70). The output is kinda contrived because godoc actually checks what the output of your code is to guarantee that the example is correct. There are test credentials you can get through your account but I need to find out if it's something that needs to be secure or not.
