### PR TITLE
make callback handlers not block the HTTP request from finishing

### DIFF
--- a/sms/callback.go
+++ b/sms/callback.go
@@ -67,6 +67,9 @@ func CallbackHandler(callbackChan chan Callback) http.HandlerFunc {
 			return
 		}
 		resp.WriteHeader(http.StatusOK)
-		callbackChan <- cb
+		// start seperate goroutine to allow http request to return.
+		go func() {
+			callbackChan <- cb
+		}()
 	})
 }

--- a/sms/callback_test.go
+++ b/sms/callback_test.go
@@ -54,14 +54,17 @@ func TestCallbackHandler(t *testing.T) {
 	req := makeTestCallbackReq()
 	cbChan := make(chan Callback)
 	handler := CallbackHandler(cbChan)
-	go func() {
-		cb := <-cbChan
-		if cb.AccountSid != testSmsCallbackFixture.AccountSid {
-			t.Error("CallbackHandler failed to parse the Callback properly")
-		}
-	}()
 
+	// send HTTP request to handler
 	handler(resp, req)
+	// HTTP request ends and is THEN sends the callback into the channel
+	cb := <-cbChan
+	if cb.AccountSid != testSmsCallbackFixture.AccountSid {
+		t.Error("CallbackHandler failed to parse the Callback properly")
+	}
+	if cb.AccountSid != testSmsCallbackFixture.AccountSid {
+		t.Error("CallbackHandler failed to parse the Callback properly")
+	}
 	if resp.Code != http.StatusOK {
 		t.Error("CallbackHandler failed to write successful status")
 	}
@@ -74,8 +77,11 @@ func TestCallbackHandlerOnFailure(t *testing.T) {
 	cbChan := make(chan Callback)
 	handler := CallbackHandler(cbChan)
 
+	// call handler with an httptest response recorder and an invalid request
 	handler(resp, req)
 	if resp.Code != 400 {
 		t.Errorf("CallbackHandler failed to write failure status, wrote %d", resp.Code)
+	} else if len(cbChan) > 1 {
+		t.Errorf("Value found in callback chennel after processing invalid request.")
 	}
 }

--- a/usage/callback.go
+++ b/usage/callback.go
@@ -64,6 +64,9 @@ func CallbackHandler(callbackChan chan TriggerCallback) http.HandlerFunc {
 			return
 		}
 		resp.WriteHeader(http.StatusOK)
-		callbackChan <- cb
+		// start seperate goroutine to allow http request to return.
+		go func() {
+			callbackChan <- cb
+		}()
 	})
 }


### PR DESCRIPTION
in the case that the channel was full, the callback handler would be blocked trying to send a value into the channel. by spawning off another goroutine, that goroutine will be blocked, not the http request.
