### PR TITLE
TwiML: add more properties for NumberOpts and ClientOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ You can generate a callback parser for all Twilio callbacks that will publish th
 [See the SMS example below for an example of how this works.](#sms_example)
 
 
-
-
 ## Installation
 
 ```
@@ -44,9 +42,6 @@ act := twilogo.NewAccountFromEnv()
 act := twiliogo.NewAccount("AccountSid", "AccountToken")
 ```
 
-
-
-
 ### Making a call
 
 ```go
@@ -58,9 +53,6 @@ resp, err := act.Voice.Call(voice.Post{
 	URL:  "http://twimlbin.com/mytwiml",
 })
 ```
-
-
-
 
 ### Sending a text - with a callback handler <a name="sms_example"></a>
 

--- a/twiml/noun_client.go
+++ b/twiml/noun_client.go
@@ -10,8 +10,11 @@ type client struct {
 //
 // https://www.twilio.com/docs/api/twiml/client
 type ClientOpts struct {
-	URL    string `xml:"url,attr,omitempty"`
-	Method string `xml:"method,attr,omitempty"`
+	URL                  string `xml:"url,attr,omitempty"`
+	Method               string `xml:"method,attr,omitempty"`
+	StatusCallbackEvent  string `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback       string `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod string `xml:"statusCallbackMethod,attr,omitempty"`
 }
 
 func addClient(t twimlResponse, opts *ClientOpts, clients []string) {

--- a/twiml/noun_number.go
+++ b/twiml/noun_number.go
@@ -10,9 +10,12 @@ type number struct {
 //
 // https://www.twilio.com/docs/api/twiml/number
 type NumberOpts struct {
-	SendDigits string `xml:"sendDigits,attr,omitempty"`
-	URL        string `xml:"url,attr,omitempty"`
-	Method     string `xml:"method,attr,omitempty"`
+	SendDigits           string `xml:"sendDigits,attr,omitempty"`
+	URL                  string `xml:"url,attr,omitempty"`
+	Method               string `xml:"method,attr,omitempty"`
+	StatusCallbackEvent  string `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback       string `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod string `xml:"statusCallbackMethod,attr,omitempty"`
 }
 
 func addNumber(t twimlResponse, opts *NumberOpts, numbers []string) {

--- a/twiml/verb_dial.go
+++ b/twiml/verb_dial.go
@@ -12,14 +12,17 @@ type dial struct {
 //
 // https://www.twilio.com/docs/api/twiml/dial
 type DialOpts struct {
-	Action       string `xml:"action,attr,omitempty"`
-	Method       string `xml:"method,attr,omitempty"`
-	Timeout      int    `xml:"timeout,attr,omitempty"`
-	HangupOnStar bool   `xml:"hangupOnStar,attr,omitempty"`
-	TimeLimit    int    `xml:"timeLimit,attr,omitempty"`
-	CallerID     string `xml:"callerId,attr,omitempty"`
-	Record       string `xml:"record,attr,omitempty"`
-	Trim         string `xml:"trim,attr,omitempty"`
+	Action                        string `xml:"action,attr,omitempty"`
+	Method                        string `xml:"method,attr,omitempty"`
+	Timeout                       int    `xml:"timeout,attr,omitempty"`
+	HangupOnStar                  bool   `xml:"hangupOnStar,attr,omitempty"`
+	TimeLimit                     int    `xml:"timeLimit,attr,omitempty"`
+	CallerID                      string `xml:"callerId,attr,omitempty"`
+	Record                        string `xml:"record,attr,omitempty"`
+	Trim                          string `xml:"trim,attr,omitempty"`
+	RecordingStatusCallback       string `xml:"recordingStatusCallback,attr,omitempty"`
+	RecordingStatusCallbackMethod string `xml:"recordingStatusCallbackMethod,attr,omitempty"`
+	RingTone                      string `xml:"ringTone,attr,omitempty"`
 }
 
 type dialBody interface {


### PR DESCRIPTION
As per docs:
- https://www.twilio.com/docs/api/twiml/client
- https://www.twilio.com/docs/api/twiml/number

added `StatusCallbackEvent` `StatusCallback ` `StatusCallbackMethod `

see #73 